### PR TITLE
build: add ngc to build process for aot (#34)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,9 +1,47 @@
 {
     "name": "@kaiu/serializer",
-    "version": "0.5.5",
+    "version": "1.0.0",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {
+        "@angular/compiler": {
+            "version": "4.3.3",
+            "resolved": "https://registry.npmjs.org/@angular/compiler/-/compiler-4.3.3.tgz",
+            "integrity": "sha1-jBWC/iinhEATJeUaBKmza2cSAz4=",
+            "dev": true,
+            "requires": {
+                "tslib": "1.7.1"
+            }
+        },
+        "@angular/compiler-cli": {
+            "version": "4.3.3",
+            "resolved": "https://registry.npmjs.org/@angular/compiler-cli/-/compiler-cli-4.3.3.tgz",
+            "integrity": "sha1-s+OZkdGirBRFpKehIuKdzlSSxjc=",
+            "dev": true,
+            "requires": {
+                "@angular/tsc-wrapped": "4.3.3",
+                "minimist": "1.2.0",
+                "reflect-metadata": "0.1.10"
+            }
+        },
+        "@angular/core": {
+            "version": "4.3.3",
+            "resolved": "https://registry.npmjs.org/@angular/core/-/core-4.3.3.tgz",
+            "integrity": "sha1-jmp2kUZh20B/otiN0kQcTAFv9iU=",
+            "dev": true,
+            "requires": {
+                "tslib": "1.7.1"
+            }
+        },
+        "@angular/tsc-wrapped": {
+            "version": "4.3.3",
+            "resolved": "https://registry.npmjs.org/@angular/tsc-wrapped/-/tsc-wrapped-4.3.3.tgz",
+            "integrity": "sha1-xYkPdDZkvmS3nCAK5unaXSqAH1s=",
+            "dev": true,
+            "requires": {
+                "tsickle": "0.21.6"
+            }
+        },
         "@types/chai": {
             "version": "4.0.1",
             "resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.0.1.tgz",
@@ -5309,6 +5347,15 @@
             "integrity": "sha1-pfE/957zt0D+MKqAP7CfmIBdR4I=",
             "dev": true
         },
+        "rxjs": {
+            "version": "5.4.2",
+            "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-5.4.2.tgz",
+            "integrity": "sha1-KjI2/L8D31e64G/Wly/ZnlwI/Pc=",
+            "dev": true,
+            "requires": {
+                "symbol-observable": "1.0.4"
+            }
+        },
         "safe-buffer": {
             "version": "5.1.1",
             "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
@@ -5960,6 +6007,12 @@
             "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
             "dev": true
         },
+        "symbol-observable": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.0.4.tgz",
+            "integrity": "sha1-Kb9hXUqnEhvdiYsi1LP5vE4qoD0=",
+            "dev": true
+        },
         "tapable": {
             "version": "0.2.7",
             "resolved": "https://registry.npmjs.org/tapable/-/tapable-0.2.7.tgz",
@@ -6180,6 +6233,18 @@
                     "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
                     "dev": true
                 }
+            }
+        },
+        "tsickle": {
+            "version": "0.21.6",
+            "resolved": "https://registry.npmjs.org/tsickle/-/tsickle-0.21.6.tgz",
+            "integrity": "sha1-U7Abl5xcE/2xOvs/uVgXflmRWI0=",
+            "dev": true,
+            "requires": {
+                "minimist": "1.2.0",
+                "mkdirp": "0.5.1",
+                "source-map": "0.5.6",
+                "source-map-support": "0.4.15"
             }
         },
         "tslib": {

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "types": "./index.d.ts",
     "scripts": {
         "build:umd": "webpack --config webpack.config.umd.ts",
-        "build:dist": "npm run build:umd",
+        "build:dist": "npm run build:umd && npm run build:ngc",
+        "build:ngc": "ngc -p tsconfig-ngc.json",
         "build:clean": "del-cli dist",
         "test": "karma start --single-run && npm run build:dist && npm run build:clean",
         "test:watch": "karma start --auto-watch",
@@ -48,6 +49,9 @@
     },
     "homepage": "https://github.com/kaiu-lab/serializer#readme",
     "devDependencies": {
+        "@angular/compiler": "^4.3.3",
+        "@angular/compiler-cli": "^4.3.3",
+        "@angular/core": "^4.3.3",
         "@types/chai": "^4.0.0",
         "@types/mocha": "^2.2.41",
         "@types/node": "^8.0.10",
@@ -72,6 +76,7 @@
         "karma-webpack": "^2.0.1",
         "mocha": "^3.3.0",
         "reflect-metadata": "^0.1.10",
+        "rxjs": "^5.0.1",
         "sinon": "^3.1.0",
         "sinon-chai": "^2.8.0",
         "standard-version": "^4.0.0",

--- a/tsconfig-ngc.json
+++ b/tsconfig-ngc.json
@@ -1,0 +1,28 @@
+{
+    "compilerOptions": {
+        "target": "es5",
+        "module": "es2015",
+        "moduleResolution": "node",
+        "declaration": true,
+        "experimentalDecorators": true,
+        "baseUrl": "",
+        "stripInternal": true,
+        "outDir": "./dist",
+        "sourceMap": true,
+        "inlineSources": true,
+        "types": [],
+        "lib": [
+            "es2015",
+            "dom"
+        ]
+    },
+    "files": [
+        "src/index.ts"
+    ],
+    "angularCompilerOptions": {
+        "strictMetadataEmit": true,
+        "genDir": "./dist/",
+        "skipTemplateCodegen": true,
+        "debug": true
+    }
+}


### PR DESCRIPTION
We need to add aot support on this level of the library because ngc requires metadata in the dependencies, meaning that if the dependencies do not ship their metadata, the ngc build will fail.