### PR TITLE
fix: remove value copy if it's undefined to avoid erasing default value

### DIFF
--- a/src/serializer.ts
+++ b/src/serializer.ts
@@ -1,11 +1,11 @@
 import 'reflect-metadata';
-import { Class, Instantiable } from './class';
-import { METADATA_DESERIALIZE_AS } from './decorator/deserialize-as';
-import { METADATA_DESERIALIZE_FIELD_NAME } from './decorator/deserialize-field-name';
-import { METADATA_CUSTOM_FIELDS } from './decorator/field-name';
-import { Registry } from './registry';
-import { METADATA_SERIALIZE_FIELD_NAME } from './decorator/serialize-field-name';
-import { METADATA_TRANSIENT_PROPERTY } from './decorator/transient';
+import {Class, Instantiable} from './class';
+import {METADATA_DESERIALIZE_AS} from './decorator/deserialize-as';
+import {METADATA_DESERIALIZE_FIELD_NAME} from './decorator/deserialize-field-name';
+import {METADATA_CUSTOM_FIELDS} from './decorator/field-name';
+import {Registry} from './registry';
+import {METADATA_SERIALIZE_FIELD_NAME} from './decorator/serialize-field-name';
+import {METADATA_TRANSIENT_PROPERTY} from './decorator/transient';
 
 /**
  * The main class of the serializer, used to deserialize `Objects` into class instances in order to add
@@ -203,7 +203,10 @@ export class Serializer {
                 result[targetPropertyName] = this.deserialize(obj[originalPropertyName], propClazz, additionalData);
             } else {
                 //Else we can copy the object as it is, since we don't need to create a specific object instance.
-                result[targetPropertyName] = obj[originalPropertyName];
+                //But keep in mind we only want to copy the value if it's not undefined, to avoid overriding default values.
+                if (obj[originalPropertyName] !== undefined) {
+                    result[targetPropertyName] = obj[originalPropertyName];
+                }
             }
         }
         return result as T;

--- a/src/serializer.ts
+++ b/src/serializer.ts
@@ -1,11 +1,11 @@
 import 'reflect-metadata';
-import {Class, Instantiable} from './class';
-import {METADATA_DESERIALIZE_AS} from './decorator/deserialize-as';
-import {METADATA_DESERIALIZE_FIELD_NAME} from './decorator/deserialize-field-name';
-import {METADATA_CUSTOM_FIELDS} from './decorator/field-name';
-import {Registry} from './registry';
-import {METADATA_SERIALIZE_FIELD_NAME} from './decorator/serialize-field-name';
-import {METADATA_TRANSIENT_PROPERTY} from './decorator/transient';
+import { Class, Instantiable } from './class';
+import { METADATA_DESERIALIZE_AS } from './decorator/deserialize-as';
+import { METADATA_DESERIALIZE_FIELD_NAME } from './decorator/deserialize-field-name';
+import { METADATA_CUSTOM_FIELDS } from './decorator/field-name';
+import { Registry } from './registry';
+import { METADATA_SERIALIZE_FIELD_NAME } from './decorator/serialize-field-name';
+import { METADATA_TRANSIENT_PROPERTY } from './decorator/transient';
 
 /**
  * The main class of the serializer, used to deserialize `Objects` into class instances in order to add

--- a/test/serializer.spec.ts
+++ b/test/serializer.spec.ts
@@ -1,7 +1,7 @@
-import { expect } from 'chai';
-import { mock, SinonMock } from 'sinon';
-import { DeserializeAs, DeserializeFieldName, FieldName, Registry, Serializer } from '../src';
-import { SerializeFieldName, Transient } from '../src/decorator';
+import {expect} from 'chai';
+import {mock, SinonMock} from 'sinon';
+import {DeserializeAs, DeserializeFieldName, FieldName, Registry, Serializer} from '../src';
+import {SerializeFieldName, Transient} from '../src/decorator';
 
 class Foo {
     public attrString: string;
@@ -81,6 +81,10 @@ class RecursiveTransient {
     bar: string;
 
     data: TransientProperty;
+}
+
+class ClassWithDefaultValue {
+    id = 'default';
 }
 
 describe('Serializer service', () => {
@@ -270,6 +274,11 @@ describe('Serializer service', () => {
             obj.data.bar = 'baz';
             obj.data.password = 'Super secret';
             expect(serializer.serialize(obj)).to.equal('{"bar":"foo","data":{"bar":"baz"}}');
+        });
+
+        it('shouldn\'t copy over default value if new value is undefined', () => {
+            const obj = {};
+            expect(serializer.deserialize<ClassWithDefaultValue>(obj, ClassWithDefaultValue).id).to.equal('default');
         });
     });
 });

--- a/test/serializer.spec.ts
+++ b/test/serializer.spec.ts
@@ -1,7 +1,7 @@
-import {expect} from 'chai';
-import {mock, SinonMock} from 'sinon';
-import {DeserializeAs, DeserializeFieldName, FieldName, Registry, Serializer} from '../src';
-import {SerializeFieldName, Transient} from '../src/decorator';
+import { expect } from 'chai';
+import { mock, SinonMock } from 'sinon';
+import { DeserializeAs, DeserializeFieldName, FieldName, Registry, Serializer } from '../src';
+import { SerializeFieldName, Transient } from '../src/decorator';
 
 class Foo {
     public attrString: string;


### PR DESCRIPTION
The idea is to avoid erasing default values on models when we copy them during deserialization.

Example:

```
export class FooModel {
  id = 'barId';
}
```

If we deserialize `{}` to `FooModel`, `result.d` will be equal to `undefined` while it should be equal to `'barId` as it's the default value.