### PR TITLE
feat: support for inheritFrom option in parent options

### DIFF
--- a/src/registration.ts
+++ b/src/registration.ts
@@ -21,7 +21,19 @@ import { ParentOptions } from './decorator/parent-options';
  * ```
  */
 export interface Registration {
+    /**
+     * The class holding the discrimination logic that should be used for this entry.
+     */
     parent: Class;
+    /**
+     * If you want to introduce discrimination logic on a class provided by an external library,
+     * You have to use inheritFrom in order to give the parent class that should be used for
+     * inheritence checks inside the serializer
+     */
+    inheritFrom?: Class;
+    /**
+     * Possible children, by key.
+     */
     children: { [index: string]: Class };
 }
 

--- a/src/registration.ts
+++ b/src/registration.ts
@@ -20,21 +20,22 @@ import { ParentOptions } from './decorator/parent-options';
  * ]
  * ```
  */
-export interface Registration {
+export interface Registration<T = any> {
     /**
-     * The class holding the discrimination logic that should be used for this entry.
+     * The class that all children have to extend no matter what.
+     *
+     * It can contain the discrimination logic, but if you want to handle inheritance constraint and discriminator separately,
+     * you have to specify the handler class in `discriminatorHandler`
      */
-    parent: Class;
+    parent: Class<T>;
     /**
-     * If you want to introduce discrimination logic on a class provided by an external library,
-     * You have to use inheritFrom in order to give the parent class that should be used for
-     * inheritence checks inside the serializer
+     * Used to define which class handles the discrimination logic, defaults to `parent`'s value.
      */
-    inheritFrom?: Class;
+    discriminatorHandler?: Class;
     /**
      * Possible children, by key.
      */
-    children: { [index: string]: Class };
+    children: { [index: string]: Class<T> };
 }
 
 /**

--- a/src/registry.ts
+++ b/src/registry.ts
@@ -79,17 +79,17 @@ export class Registry {
             } else {
                 children = reg.children;
 
+                const discriminatorHandler = reg.discriminatorHandler || reg.parent;
+
                 //Get the metadata for this parent and check if it has the @Parent decorator.
-                parentOptions = Reflect.getOwnMetadata(METADATA_PARENT, reg.parent);
+                parentOptions = Reflect.getOwnMetadata(METADATA_PARENT, discriminatorHandler);
                 if (parentOptions === undefined) {
-                    throw new TypeError(`Class ${reg.parent.name} needs a @Parent decorator to be registered`);
+                    throw new TypeError(`Class ${discriminatorHandler.name} needs a @Parent decorator to be registered`);
                 }
             }
 
             // Flag to know if the parent is registered among its children.
             let parentHasExplicitDiscriminator = false;
-
-            const inheritFrom = reg.inheritFrom || reg.parent;
 
             for (const value in reg.children) {
                 const child = reg.children[value];
@@ -103,8 +103,8 @@ export class Registry {
                     parentHasExplicitDiscriminator = true;
                 } else {
                     //Check if the child extends the parent
-                    if (!(child.prototype instanceof inheritFrom)) {
-                        throw new TypeError(`Class ${child.name} needs to extend ${inheritFrom.name} to be registered as a child`);
+                    if (!(child.prototype instanceof reg.parent)) {
+                        throw new TypeError(`Class ${child.name} needs to extend ${reg.parent.name} to be registered as a child`);
                     }
                 }
             }

--- a/src/registry.ts
+++ b/src/registry.ts
@@ -89,6 +89,8 @@ export class Registry {
             // Flag to know if the parent is registered among its children.
             let parentHasExplicitDiscriminator = false;
 
+            const inheritFrom = reg.inheritFrom || reg.parent;
+
             for (const value in reg.children) {
                 const child = reg.children[value];
 
@@ -101,8 +103,8 @@ export class Registry {
                     parentHasExplicitDiscriminator = true;
                 } else {
                     //Check if the child extends the parent
-                    if (!(child.prototype instanceof reg.parent)) {
-                        throw new TypeError(`Class ${child.name} needs to extend ${reg.parent.name} to be registered as a child`);
+                    if (!(child.prototype instanceof inheritFrom)) {
+                        throw new TypeError(`Class ${child.name} needs to extend ${inheritFrom.name} to be registered as a child`);
                     }
                 }
             }

--- a/test/registry.spec.ts
+++ b/test/registry.spec.ts
@@ -42,6 +42,16 @@ class ParentWithTrackBy {
 class ChildWithTrackBy extends ParentWithTrackBy {
 }
 
+@Parent({
+    discriminatorField: 'foo',
+    trackBy: (value: any) => {
+        return value[1];
+    }
+})
+class DiscriminatorHandler {
+    foo: string[];
+}
+
 
 describe('Registry service', () => {
     let registry: Registry;
@@ -360,6 +370,23 @@ describe('Registry service', () => {
             );
 
             expect(registry.findClass(ParentWithTrackBy, {foo: ['valueFromTrackBy']})).to.equal(ChildWithTrackBy);
+        });
+    });
+
+    describe('DiscriminatorHandler tests', () => {
+        it('Should use discriminatorHandler field when it has been set', () => {
+            registry.add([
+                    {
+                        parent: ParentWithTrackBy,
+                        discriminatorHandler: DiscriminatorHandler,
+                        children: {
+                            'valueFromTrackBy': ChildWithTrackBy
+                        },
+                    },
+                ],
+            );
+
+            expect(registry.findClass(ParentWithTrackBy, {foo: ['nope', 'valueFromTrackBy']})).to.equal(ChildWithTrackBy);
         });
     });
 


### PR DESCRIPTION
The idea is to be able to support inheritance on external classes with our discriminant system.

## Example

Let's say I'm using a library providing a set of classes for my model system (typical case when you're using Nx). I want to be able to connect discriminator logic on classes that I can't write on, but at the moment we can't do this because the system needs children to extend the parent, which is understandable.

## Proposal

The idea is to be able to use a "discriminator holder" class as `discriminatorHandler`, and use another class as parent. This way, you can't just inherit from whatever, it's not disabled, it's just that the inheritance constraint is placed on another class, making it easy to support external library models without breaking changes.